### PR TITLE
Increase speed decrease false positives

### DIFF
--- a/PII_stata_scan.do
+++ b/PII_stata_scan.do
@@ -41,7 +41,6 @@ global search_strings
 	compound
 	coord
 	country
-	degree
 	district
 	daughter
 	email
@@ -54,8 +53,7 @@ global search_strings
 	landline
 	latitude
 	location
-	longitude 
-	minute
+	longitude
 	mother
 	municipality
 	name
@@ -65,7 +63,6 @@ global search_strings
 	phone 
 	precinct
 	school
-	second
 	sex
 	social
 	spouse 
@@ -322,6 +319,31 @@ program pii_scan
 		*Remove duplicates in list of flagged vars:
 		local flagged_vars : list uniq flagged_vars
 		
+		*Search through the remaining variables to see if there are variables for degree minute second. Only output the variables if all three are present, otherwise they are not likely to be PII:
+		*initialize locals:
+		foreach gps_string in degree minute second {
+			local `gps_string' = 0
+			local `gps_string'_vars
+		}
+		local gps_var_search : list all_vars - flagged_vars
+		foreach var of local gps_var_search {
+			local var_name = lower("`var'")
+			local lab: variable label `var'
+			local var_label = lower("`lab'")
+			foreach gps_string in degree minute second {
+				if strmatch("`var_name'","*`gps_string'*")==1 | strmatch("`var_label'","*`gps_string'*")==1 { 
+					local `gps_string' = 1
+					local `gps_string'_vars "``gps_string'_vars' `var'"
+				}
+			}
+		}
+		if `degree'==1 & `minute'==1 & `second' == 1 {
+			local flagged_vars "`flagged_vars' `degree_vars' `minute_vars' `second_vars'"
+		}
+		
+		*Remove duplicates in list of flagged vars:
+		local flagged_vars : list uniq flagged_vars
+			
 	
 		***Search through the variables and see if there are any of the PII search words in the variable names or labels:
 		***Only look through variables that havent been assigned to be output to CSV sheet already

--- a/PII_stata_scan.do
+++ b/PII_stata_scan.do
@@ -43,7 +43,6 @@ global search_strings
 	country
 	degree
 	district
-	dob
 	daughter
 	email
 	father
@@ -54,7 +53,6 @@ global search_strings
 	husband
 	landline
 	latitude
-	loc
 	location
 	longitude 
 	minute
@@ -70,15 +68,20 @@ global search_strings
 	second
 	sex
 	social
-	son
 	spouse 
 	street
 	subcountry
 	territory
-	url
 	village
 	wife
 	zip
+;
+
+global strict_search_strings
+	url
+	son
+	dob
+	loc
 ;
 #delimit cr;
 *****************************************************************************************************
@@ -149,6 +152,7 @@ program pii_scan
 	file write output_file _n
 	
 	local total_variables = 0 // used to count/display total number of variables at end
+	local total_variables_flagged = 0 // used to count/display number of FLAGGED variables at the end
 	local backtick `"`"'
 	qui count
 	forvalues i=1/`r(N)' {
@@ -163,10 +167,18 @@ program pii_scan
 		local string_vars
 		local numeric_vars 
 		local all_vars
+		local flagged_vars
 		
 		*Drop any variables with strings in the user defined "ignore" list:
-		foreach substring of local ignore_varname {
-			cap drop *`substring'*
+		foreach ignore_string of local ignore_varname {
+			foreach var of varlist * {
+				local var_name = lower("`var'")
+				local lower_ignore_string = lower("`ignore_string'")
+				local ignore_name_pos = strpos("`var_name'","`lower_ignore_string'")
+				if `ignore_name_pos'!=0 {
+					drop `var'
+				}
+			}
 		}
 		
 		foreach var of varlist * {
@@ -229,30 +241,134 @@ program pii_scan
 			}
 		}
 		
-		***Search through the variables and see if there are any of the PII search words in the variable names or labels:
-		***Only look through variables that havent been assigned to be output to CSV sheet already
-		*local search_list : list all_vars - strings_to_output 
-		local flagged_vars "" // local flagged_vars "`strings_to_output'"
-		foreach var of local all_vars { // foreach var of local search_list {
+		
+		*** Search through ALL the variables to see if there is a PAIR of variables for lat/lon:
+		*First see if there are two variables "lat" and "lon" anywhere in the datafile:
+		local lat = 0
+		local lon = 0
+		foreach var of local all_vars {
+			if lower("`var'")=="lat" {
+				local lat = 1
+				local lat_var "`var'"
+			}
+			if lower("`var'")=="lon" {
+				local lon = 1
+				local lon_var "`var'"
+			}
+		}
+		if `lat'==1 & `lon'==1 {
+			local flagged_vars "`lat_var' `lon_var'"
+		}
+		
+		local total_vars = 0
+		foreach var of local all_vars {
+			local ++total_vars
 			local lab: variable label `var'
 			local var_label = lower("`lab'")
 			local var_name = lower("`var'")
-			foreach search_string of global final_search_list {
-				local search_string = lower(`"`search_string'"')
-				***Look for string in variable name:
-				local name_pos = strpos("`var_name'","`search_string'")
-				***Look for string in variable label: 
-				local label_pos = strpos("`var_label'","`search_string'")
-				if `name_pos'!=0 | `label_pos' !=0 {
-					display "search term `search_string' found in `var' (label = `var_label')"
-					local flagged_vars "`flagged_vars' `var'"
+			
+			local var`total_vars' "`var_name'"
+			local var_orig_case`total_vars' "`var'"
+			local var_label`total_vars' "`var_label'"
+		}
+		local var_num = 0
+		foreach var of local all_vars {
+			local ++var_num
+			local prev_var_num = `var_num' - 1
+			local next_var_num = `var_num' + 1
+			
+			if `var_num'!= 1 {
+				local prev_var "`var`prev_var_num''"
+				local prev_var_orig_case "`var_orig_case`prev_var_num''"
+				local prev_var_label "`var_label`prev_var_num''"
+			}
+			else {
+				local prev_var
+				local prev_var_orig_case
+				local prev_var_label
+			}
+			if `var_num' != `total_vars' {
+				local next_var "`var`next_var_num''"
+				local next_var_orig_case "`var_orig_case`next_var_num''"
+				local next_var_label "`var_label`next_var_num''"
+			}
+			else {
+				local next_var
+				local next_var_orig_case
+				local next_var_label
+			}
+				
+			local lab: variable label `var'
+			local var_label = lower("`lab'")
+			local var_name = lower("`var'")
+			
+			*If "lat" is in the variable name or label, see if "lon" is in the next or previous variables name or label:
+			if strmatch("`var_name'","*lat*")==1 | strmatch("`var_label'","*lat*")==1 {
+				*if it's in the PREV variable name or label:
+				if strmatch("`prev_var'","*lon*")==1 |  strmatch("`prev_var_label'","*lon*")==1 {
+					*ADD CURRENT VARIABLE AND PREVOUS VARIABLE TO FLAGGED:
+					local flagged_vars "`flagged_vars' `var' `prev_var_orig_case'"
+				}
+				*if it's in the NEXT variable name or label:
+				if strmatch("`next_var'","*lon*")==1 | strmatch("`next_var_label'","*lon*")==1 {
+					* ADD CURRENT VARIABLE AND NEXT VARIABLE TO FLAGGED:
+					local flagged_vars "`flagged_vars' `var' `next_var_orig_case'"
 				}
 			}
 		}
 		
+		*Remove duplicates in list of flagged vars:
+		local flagged_vars : list uniq flagged_vars
+		
+	
+		***Search through the variables and see if there are any of the PII search words in the variable names or labels:
+		***Only look through variables that havent been assigned to be output to CSV sheet already
+		local search_list : list all_vars - flagged_vars 
+		*local flagged_vars "`strings_to_output'"
+		foreach var of local search_list {
+			local lab: variable label `var'
+			local var_label = lower("`lab'")
+			local var_name = lower("`var'")
+			local keep_searching = 1
+			foreach search_string of global final_search_list {
+				if `keep_searching' == 1 {
+					local search_string = lower(`"`search_string'"')
+					***Look for string in variable name:
+					local name_pos = strpos("`var_name'","`search_string'")
+					***Look for string in variable label: 
+					local label_pos = strpos("`var_label'","`search_string'")
+					if `name_pos'!=0 | `label_pos' !=0 {
+						display "search term `search_string' found in `var' (label = `var_label')"
+						local flagged_vars "`flagged_vars' `var'"
+						local keep_searching = 0
+					}
+				}
+			}
+			
+			* If the variable hasnt been flagged yet look through the strict search terms list:
+			if `keep_searching' == 1 {
+				foreach str of global strict_search_strings {
+					if `keep_searching' == 1 {
+						*Search the variable name for the exact match or a match at the beginning or end of the variable name or in the middle separated by "_":
+						if "`var_name'"=="`str'" | strmatch("`var_name'","*`str'")==1 | strmatch("`var_name'","`str'*")==1 | strmatch("`var_name'","*_`str'_*")==1 {
+							display "Strict search term `str' found in `var' (label = `var_label')"
+							local flagged_vars "`flagged_vars' `var'"
+							local keep_searching = 0
+						}
+						
+						*labels: - search for the full word in the label:
+						if "`var_label'"=="`str'" | strmatch("`var_label'","* `str' *")==1 | strmatch("`var_label'","* `str'")==1 | strmatch("`var_label'","`str' *")==1 {
+							display "Strict search term `str' found in `var' (label = `var_label')"
+							local flagged_vars "`flagged_vars' `var'"
+							local keep_searching = 0
+						}
+					}
+				}	
+			}	
+		}
+		
 		
 		*** Search through the STRING variables that havent been flagged by the name/label search to find variables with lengths greater than 3:
-		*******local search_list : list all_vars - strings_to_output 
 		local string_vars_to_search : list string_vars - flagged_vars
 		foreach var of local string_vars_to_search {
 			tempvar temp1
@@ -285,6 +401,7 @@ program pii_scan
 				
 		***Output the flagged variables to csv file: 
 		foreach var of local flagged_vars {
+			local ++total_variables_flagged
 			tempvar obsnm_temp temp2 temp3 temp4 temp5
 			qui egen `temp2' = group(`var') // group var
 			qui egen `temp3' = mode(`temp2'), maxmode // mode of GROUP
@@ -341,13 +458,19 @@ program pii_scan
 
 	file close output_file
 
+	display ""
+	display "------------------------------------------------------------"
 	if !missing("`time'") {
+		display ""
 		display "START TIME = `start_time'"
 		display "END TIME = " c(current_time)
 	}
-	
-	display "NUMBER OF FILES SCANNED = `total_files'"
-	display "NUMBER OF VARIABLES SCANND = `total_variables'"
+	display ""
+	display "FILES SCANNED = `total_files'"
+	display "VARIABLES SCANNED = `total_variables'"
+	display "VARIABLES WITH POTENTIAL PII = `total_variables_flagged'"
+	display ""
+	display "------------------------------------------------------------"
 end
 
 

--- a/PII_stata_scan.do
+++ b/PII_stata_scan.do
@@ -306,11 +306,13 @@ program pii_scan
 			if strmatch("`var_name'","*lat*")==1 | strmatch("`var_label'","*lat*")==1 {
 				*if it's in the PREV variable name or label:
 				if strmatch("`prev_var'","*lon*")==1 |  strmatch("`prev_var_label'","*lon*")==1 {
+					display "lat/lon variable found: `var' (label = `var_label')"
 					*ADD CURRENT VARIABLE AND PREVOUS VARIABLE TO FLAGGED:
 					local flagged_vars "`flagged_vars' `var' `prev_var_orig_case'"
 				}
 				*if it's in the NEXT variable name or label:
 				if strmatch("`next_var'","*lon*")==1 | strmatch("`next_var_label'","*lon*")==1 {
+					display "lat/lon variable found: `var' (label = `var_label')"
 					* ADD CURRENT VARIABLE AND NEXT VARIABLE TO FLAGGED:
 					local flagged_vars "`flagged_vars' `var' `next_var_orig_case'"
 				}
@@ -398,7 +400,11 @@ program pii_scan
 				local flagged_vars : list flagged_vars - var
 			}
 		}
-				
+		
+		*Drop the non-flagged variables:
+		keep `flagged_vars'
+		qui duplicates drop
+		
 		***Output the flagged variables to csv file: 
 		foreach var of local flagged_vars {
 			local ++total_variables_flagged
@@ -452,6 +458,7 @@ program pii_scan
 				}
 			}
 			drop `obsnm_temp' `temp2' `temp3' `temp4' `temp5'
+			drop `var'
 			file write output_file _n
 		}
 	}


### PR DESCRIPTION
The branch makes the following modifications:
- adds "landline" and "cell" to search terms 
- Switch the order of the name/label search and the string length search. String length is more computationally intensive and needs to go second. 
- Remove lat/lon search strings and implements a search procedure that only flags variables with lat/lon in them if they are adjacent columns. The full words "latitude" and "longitude" are retained in the search strings, so if these terms come up in any variables or labels they will be flagged, regardless of whether they are adjacent columns. 
- Create a “strict matching” criteria for the following search strings “url, son, dob, loc”. Only flag variable names if they have the following match patterns: `*url`, `url*`, `*_url_*`. It will only flag variable labels if they contain the exact word (i.e. contains a space before and after the string.) 
- Drop non-flagged variables before writing output and drop each flagged variable after the output for that variable is written (decreases sort time)
- Combine the search terms “degree, minute, second” so that variables are flagged only if all three search terms are found in the dataset.
