### PR TITLE
Fixed search item error on line 428

### DIFF
--- a/PII_stata_scan.do
+++ b/PII_stata_scan.do
@@ -425,7 +425,7 @@ program pii_scan
 		}
 		
 		*Drop the non-flagged variables:
-		keep `flagged_vars'
+		capture keep `flagged_vars'
 		qui duplicates drop
 		
 		***Output the flagged variables to csv file: 

--- a/pii_scan.ado
+++ b/pii_scan.ado
@@ -397,7 +397,7 @@ program pii_scan
 		}
 		
 		*Drop the non-flagged variables:
-		keep `flagged_vars'
+		capture keep `flagged_vars'
 		qui duplicates drop
 		
 		***Output the flagged variables to csv file: 


### PR DESCRIPTION
Changed line 428 in the do file to "capture keep `flagged_vars'" to avoid an error whenever the search criteria for flagged variables does not match any variable in the dataset.