### PR TITLE
change ado-file to work as a command

### DIFF
--- a/pii_scan.ado
+++ b/pii_scan.ado
@@ -523,4 +523,3 @@ export delimited "pii_stata_output.csv", replace
 	display ""
 	display "------------------------------------------------------------"
 end
-pii_scan ${directory_to_scan}


### PR DESCRIPTION
`pii_scan [path]` should run the program if the ado-file is stored in the right directory. Previously this didn't work because the ado-file tried to call the pii_scan program itself, which in fact is not necessary.

Fixes #20